### PR TITLE
Update variables.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_storage_account" "storage" {
   account_kind                    = "StorageV2"
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
-  enable_https_traffic_only       = true
+  https_traffic_only_enabled      = true
   allow_nested_items_to_be_public = false
   min_tls_version                 = "TLS1_2"
   tags                            = merge(var.tags, {})

--- a/main.tf
+++ b/main.tf
@@ -73,14 +73,13 @@ resource "azurerm_application_insights" "insights" {
 }
 
 resource "azurerm_windows_function_app" "function" {
-  name                          = var.function_app_name
-  resource_group_name           = var.resource_group_name
-  location                      = var.location
-  service_plan_id               = azurerm_service_plan.serverfarm.id
-  storage_account_name          = azurerm_storage_account.storage.name
-  storage_account_access_key    = azurerm_storage_account.storage.primary_access_key
-  tags                          = merge(var.tags, {})
-  ip_restriction_default_action = var.ip_restriction_default_action
+  name                       = var.function_app_name
+  resource_group_name        = var.resource_group_name
+  location                   = var.location
+  service_plan_id            = azurerm_service_plan.serverfarm.id
+  storage_account_name       = azurerm_storage_account.storage.name
+  storage_account_access_key = azurerm_storage_account.storage.primary_access_key
+  tags                       = merge(var.tags, {})
 
 
   functions_extension_version = "~4"
@@ -176,6 +175,7 @@ resource "azurerm_windows_function_app" "function" {
     always_on                              = var.always_on
     app_scale_limit                        = var.app_scale_limit
     vnet_route_all_enabled                 = var.vnet_route_all_enabled
+  ip_restriction_default_action            = var.ip_restriction_default_action
 
     application_stack {
       dotnet_version = "v6.0"

--- a/main.tf
+++ b/main.tf
@@ -172,6 +172,7 @@ resource "azurerm_windows_function_app" "function" {
     minimum_tls_version                    = "1.2"
     http2_enabled                          = true
     health_check_path                      = "/dashboard"
+    health_check_eviction_time_in_min      = 2
     always_on                              = var.always_on
     app_scale_limit                        = var.app_scale_limit
     vnet_route_all_enabled                 = var.vnet_route_all_enabled

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ resource "azurerm_windows_function_app" "function" {
         client_secret_setting_name       = var.auth_settings.active_directory.client_secret_setting_name
         tenant_auth_endpoint             = "https://login.microsoftonline.com/${var.auth_settings.active_directory.tenant_id}/v2.0/"
         allowed_audiences                = var.auth_settings.active_directory.allowed_audiences
+        allowed_applications             = var.auth_settings.active_directory.allowed_applications
       }
       login {
         allowed_external_redirect_urls    = var.allowed_external_redirect_urls == null ? [] : var.allowed_external_redirect_urls

--- a/main.tf
+++ b/main.tf
@@ -73,13 +73,15 @@ resource "azurerm_application_insights" "insights" {
 }
 
 resource "azurerm_windows_function_app" "function" {
-  name                       = var.function_app_name
-  resource_group_name        = var.resource_group_name
-  location                   = var.location
-  service_plan_id            = azurerm_service_plan.serverfarm.id
-  storage_account_name       = azurerm_storage_account.storage.name
-  storage_account_access_key = azurerm_storage_account.storage.primary_access_key
-  tags                       = merge(var.tags, {})
+  name                          = var.function_app_name
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  service_plan_id               = azurerm_service_plan.serverfarm.id
+  storage_account_name          = azurerm_storage_account.storage.name
+  storage_account_access_key    = azurerm_storage_account.storage.primary_access_key
+  tags                          = merge(var.tags, {})
+  ip_restriction_default_action = var.ip_restriction_default_action
+
 
   functions_extension_version = "~4"
   https_only                  = true

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_storage_account" "storage" {
   tags                            = merge(var.tags, {})
 
   network_rules {
-    default_action             = "Deny"
+    default_action             = var.storage_account_default_action
     ip_rules                   = length(var.allowed_ip_addresses         ) > 0 ? var.allowed_ip_addresses          : null
     virtual_network_subnet_ids = concat(
       length(var.virtual_network_subnet_ids_pe         ) > 0 ? var.virtual_network_subnet_ids_pe          : [],

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,12 @@ variable "app_scale_limit" {
   default = 2
 }
 
+variable "ip_restriction_default_action" {
+  type = string
+  description = "The Default action for traffic that does not match any ip_restriction rule."
+  default = "Allow"
+}
+
 variable "vnet_route_all_enabled" {
   type = bool
   description = "Function route all traffic via vnet"

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "storage_account_name" {
   description = "The name of the Storage Account to create."
 }
 
+variable "storage_account_default_action" {
+  type        = string
+  description = "Default action for Storage Account's network rules."
+  default     = "Deny"
+}
+
 variable "app_insights_name" {
   type        = string
   description = "The name of the Application Insights to create."

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,7 @@ variable "auth_settings" {
       client_secret_setting_name = string
       tenant_id                  = string
       allowed_audiences          = list(string)
+      allowed_applications       = list(string)
     })
   })
   description = "Authentication settings for the function app"

--- a/variables.tf
+++ b/variables.tf
@@ -374,10 +374,10 @@ locals {
 
   function_ip_restrictions = {
     for l, w in concat(
-      [for v in var.allowed_ip_addresses                  : {"ip_address" =    v, "virtual_network_subnet_id" = null}],
-      [for v in var.virtual_network_subnet_ids_pe         : {"ip_address" = null, "virtual_network_subnet_id" =    v}],
-      [for v in var.virtual_network_subnet_ids_integration: {"ip_address" = null, "virtual_network_subnet_id" =    v}],
-      [for v in var.virtual_network_subnet_ids_extra      : {"ip_address" = null, "virtual_network_subnet_id" =    v}]
+      [for v in var.allowed_ip_addresses                  : {"ip_address" = length(regexall(".*\\/.*", v)) > 0 ? v : format("%s/32", v), "virtual_network_subnet_id" = null}],
+      [for v in var.virtual_network_subnet_ids_pe         : {"ip_address" =                                                        null, "virtual_network_subnet_id" =    v}],
+      [for v in var.virtual_network_subnet_ids_integration: {"ip_address" =                                                        null, "virtual_network_subnet_id" =    v}],
+      [for v in var.virtual_network_subnet_ids_extra      : {"ip_address" =                                                        null, "virtual_network_subnet_id" =    v}]
     ): l => w
   }
 


### PR DESCRIPTION
Storage does not allow /31 and /31 CIDR ranges, only smaller (/bigger). But the function app does not accept plain IP addresses, only CIDR records, so you have to append plain IP addresses with "/32" suffix.